### PR TITLE
Update the component in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,5 +13,4 @@ reviewers:
 - elmiko
 - lobziik
 - odvarkadaniel
-component: Cloud Compute
-subcomponent: Cloud Controller Manager
+component: "Cloud Compute / Cloud Controller Manager"


### PR DESCRIPTION
Updates the `component` entry to match Jira[1] instead of the old Bugzilla component and subcomponent.

[1] https://issues.redhat.com/issues/?jql=project%20%3D%20OCPBUGS%20AND%20component%20%3D%20%22Cloud%20Compute%20%2F%20Cloud%20Controller%20Manager%22
