### PR TITLE
OCPBUGS-59794: Adding nil checks to avoid Panic

### DIFF
--- a/pkg/provider/manager.go
+++ b/pkg/provider/manager.go
@@ -229,6 +229,9 @@ func (n *nutanixManager) isNodeShutdown(ctx context.Context, node *v1.Node) (boo
 }
 
 func (n *nutanixManager) isVMShutdown(vm *prismclientv3.VMIntentResponse) bool {
+	if vm == nil || vm.Spec == nil || vm.Spec.Resources == nil || vm.Spec.Resources.PowerState == nil {
+		return false
+	}
 	return *vm.Spec.Resources.PowerState == constants.PoweredOffState
 }
 
@@ -277,9 +280,18 @@ func (n *nutanixManager) getNodeAddresses(_ context.Context, vm *prismclientv3.V
 	}
 
 	var addresses []v1.NodeAddress
-	for _, nic := range vm.Status.Resources.NicList {
-		for _, ipEndpoint := range nic.IPEndpointList {
-			if ipEndpoint.IP != nil {
+	if vm.Status == nil || vm.Status.Resources == nil {
+		return nil, fmt.Errorf("vm status or resources is nil for VM")
+	}
+	if vm.Status.Resources.NicList != nil {
+		for _, nic := range vm.Status.Resources.NicList {
+			if nic == nil {
+				continue
+			}
+			for _, ipEndpoint := range nic.IPEndpointList {
+				if ipEndpoint == nil || ipEndpoint.IP == nil {
+					continue
+				}
 				// Ignore the IP address if it is one of the specified ignoredNodeIPs.
 				if _, ok := n.ignoredNodeIPs[*ipEndpoint.IP]; !ok {
 					addresses = append(addresses, v1.NodeAddress{
@@ -291,9 +303,15 @@ func (n *nutanixManager) getNodeAddresses(_ context.Context, vm *prismclientv3.V
 		}
 	}
 	if len(addresses) == 0 {
+		if vm.Metadata == nil || vm.Metadata.UUID == nil {
+			return addresses, fmt.Errorf("unable to determine network interfaces from VM: missing UUID")
+		}
 		return addresses, fmt.Errorf("unable to determine network interfaces from VM with UUID %s", *vm.Metadata.UUID)
 	}
 
+	if vm.Spec == nil || vm.Spec.Name == nil {
+		return addresses, fmt.Errorf("vm spec or name is nil")
+	}
 	addresses = append(addresses, v1.NodeAddress{
 		Type:    v1.NodeHostName,
 		Address: *vm.Spec.Name,
@@ -326,13 +344,16 @@ func (n *nutanixManager) getTopologyInfoUsingPrism(ctx context.Context, nClient 
 		return ti, fmt.Errorf("vm cannot be nil when searching for Prism topology info")
 	}
 
-	if vm.Status.ClusterReference == nil || *vm.Status.ClusterReference.Name == "" {
-		return ti, fmt.Errorf("cannot determine Prism zone information for vm %s", *vm.Spec.Name)
+	if vm.Status == nil || vm.Status.ClusterReference == nil || vm.Status.ClusterReference.Name == nil || *vm.Status.ClusterReference.Name == "" {
+		return ti, fmt.Errorf("cannot determine Prism zone information for vm")
 	}
 
 	pc, err := n.getPrismCentralCluster(ctx, nClient)
 	if err != nil {
 		return ti, err
+	}
+	if pc == nil || pc.Spec == nil || pc.Spec.Name == nil {
+		return ti, fmt.Errorf("prism central cluster or its name is nil")
 	}
 	ti.Region = *pc.Spec.Name
 	ti.Zone = *vm.Status.ClusterReference.Name
@@ -343,6 +364,9 @@ func (n *nutanixManager) getTopologyInfoUsingCategories(ctx context.Context, nut
 	tc := &config.TopologyInfo{}
 	if vm == nil {
 		return *tc, fmt.Errorf("vm cannot be nil while getting topology info")
+	}
+	if vm.Spec == nil || vm.Spec.Name == nil {
+		return *tc, fmt.Errorf("vm spec or name is nil while getting topology info")
 	}
 	klog.V(1).Infof("searching for topology info on VM entity: %s", *vm.Spec.Name)
 	err := n.getTopologyInfoFromVM(vm, tc)
@@ -392,10 +416,16 @@ func (n *nutanixManager) getTopologyInfoFromCluster(ctx context.Context, nClient
 	if ti == nil {
 		return fmt.Errorf("topology categories cannot be nil when searching for topology info")
 	}
+	if vm.Status == nil || vm.Status.ClusterReference == nil || vm.Status.ClusterReference.UUID == nil {
+		return fmt.Errorf("vm status, cluster reference, or cluster UUID is nil")
+	}
 	clusterUUID := *vm.Status.ClusterReference.UUID
 	cluster, err := nClient.GetCluster(ctx, clusterUUID)
 	if err != nil {
 		return fmt.Errorf("error occurred while searching for topology info on cluster: %v", err)
+	}
+	if cluster == nil || cluster.Metadata == nil {
+		return fmt.Errorf("cluster or cluster metadata is nil")
 	}
 	if err = n.getZoneInfoFromCategories(cluster.Metadata.Categories, ti); err != nil {
 		return err
@@ -409,6 +439,9 @@ func (n *nutanixManager) getTopologyInfoFromVM(vm *prismclientv3.VMIntentRespons
 	}
 	if ti == nil {
 		return fmt.Errorf("topology categories cannot be nil when searching for topology info")
+	}
+	if vm.Metadata == nil {
+		return fmt.Errorf("vm metadata is nil when searching for topology info")
 	}
 	if err := n.getZoneInfoFromCategories(vm.Metadata.Categories, ti); err != nil {
 		return err
@@ -453,7 +486,8 @@ func (n *nutanixManager) getPrismCentralCluster(ctx context.Context, nClient int
 }
 
 func (n *nutanixManager) hasPEClusterServiceEnabled(peCluster *prismclientv3.ClusterIntentResponse, serviceName string) bool {
-	if peCluster.Status == nil ||
+	if peCluster == nil ||
+		peCluster.Status == nil ||
 		peCluster.Status.Resources == nil ||
 		peCluster.Status.Resources.Config == nil {
 		return false

--- a/vendor/github.com/nutanix-cloud-native/prism-go-client/v3/cache.go
+++ b/vendor/github.com/nutanix-cloud-native/prism-go-client/v3/cache.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/nutanix-cloud-native/prism-go-client"
+	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	"github.com/nutanix-cloud-native/prism-go-client/environment/types"
 )
 
@@ -101,12 +101,32 @@ func (c *ClientCache) GetOrCreate(cachedClientParams CachedClientParams, opts ..
 	// validation hash is different, regenerate the client
 	c.Delete(cachedClientParams)
 
+	managementEndpoint := cachedClientParams.ManagementEndpoint()
+
+	// Defensive programming: check for nil Address pointer
+	if managementEndpoint.Address == nil {
+		return nil, fmt.Errorf("management endpoint address is nil for cachedClientParams with key %s", cachedClientParams.Key())
+	}
+
+	// Defensive programming: validate required fields
+	if managementEndpoint.Address.Host == "" {
+		return nil, fmt.Errorf("management endpoint address host is empty for cachedClientParams with key %s", cachedClientParams.Key())
+	}
+
+	if managementEndpoint.ApiCredentials.Username == "" {
+		return nil, fmt.Errorf("API credentials username is empty for cachedClientParams with key %s", cachedClientParams.Key())
+	}
+
+	if managementEndpoint.ApiCredentials.Password == "" {
+		return nil, fmt.Errorf("API credentials password is empty for cachedClientParams with key %s", cachedClientParams.Key())
+	}
+
 	credentials := prismgoclient.Credentials{
-		URL:         cachedClientParams.ManagementEndpoint().Address.Host,
-		Endpoint:    cachedClientParams.ManagementEndpoint().Address.Host,
-		Insecure:    cachedClientParams.ManagementEndpoint().Insecure,
-		Username:    cachedClientParams.ManagementEndpoint().ApiCredentials.Username,
-		Password:    cachedClientParams.ManagementEndpoint().ApiCredentials.Password,
+		URL:         managementEndpoint.Address.Host,
+		Endpoint:    managementEndpoint.Address.Host,
+		Insecure:    managementEndpoint.Insecure,
+		Username:    managementEndpoint.ApiCredentials.Username,
+		Password:    managementEndpoint.ApiCredentials.Password,
 		SessionAuth: c.useSessionAuth,
 	}
 
@@ -115,8 +135,8 @@ func (c *ClientCache) GetOrCreate(cachedClientParams CachedClientParams, opts ..
 		return nil, fmt.Errorf("failed to validate credentials for cachedClientParams with key %s: %w", cachedClientParams.Key(), err)
 	}
 
-	if cachedClientParams.ManagementEndpoint().AdditionalTrustBundle != "" {
-		opts = append(opts, WithPEMEncodedCertBundle([]byte(cachedClientParams.ManagementEndpoint().AdditionalTrustBundle)))
+	if managementEndpoint.AdditionalTrustBundle != "" {
+		opts = append(opts, WithPEMEncodedCertBundle([]byte(managementEndpoint.AdditionalTrustBundle)))
 	}
 
 	client, err = NewV3Client(credentials, opts...)


### PR DESCRIPTION
Description
Problem:
The cloud-provider-nutanix component could panic with a nil pointer dereference when certain objects or fields were unexpectedly missing or uninitialized. This caused stability and reliability issues during OpenShift cluster operations, especially when interacting with Nutanix infrastructure.

Solution:
This PR adds comprehensive nil checks to critical code paths where panics have been observed. By explicitly checking for nil before dereferencing objects or fields, the provider avoids panics and instead fails gracefully, improving robustness and error reporting.

Relevant Issue/Bug:
OCPBUGS-59794: Adding nil checks to avoid Panic

Impact:
- Prevents hard crashes due to nil pointer dereference.
- Contributes to better observability and debuggability by surfacing actual errors instead of silent panics.
- Safer cluster upgrades and day-two operations on Nutanix platforms.

